### PR TITLE
🤫 Small typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Generate boilerplate code for building v14+ Umbraco packages
 
 npm:
 ```shell
-npm i umbracodgen -g
+npm i umbracodegen -g
 ```
 
 pnpm:


### PR DESCRIPTION
Found a teeny weeny typo when copy-pasting the install command for npm.